### PR TITLE
add database.yml for different environment databases

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -1,0 +1,26 @@
+#Credit to https://stackoverflow.com/a/30571341/6715039
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+
+production:
+  adapter: sqlite3
+  database: db/production.sqlite3
+  pool: 5
+  timeout: 5000


### PR DESCRIPTION
After coding along, I had issue with`rake db:migrate` and `rake db:create`. These were complaining about development database. Adding database.yml solved the problem.